### PR TITLE
Adjusted test_valid_word test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Running tests
+
+Prep the environment:
+
+```
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run tests (inside `test.py`):
+
+```
+python -m unittest test.FlaskTests
+```

--- a/test.py
+++ b/test.py
@@ -43,8 +43,9 @@ class FlaskTests(TestCase):
                                          ['A', 'R', 'E', 'M', 'Y'],
                                          ['L', 'I', 'F', 'E', 'A'],
                                          ['N', 'A', 'D', 'O', 'G']]
-            resp = self.client.post('/check-entry', json={'entry': 'GAME'})
-            self.assertEqual(resp.json['result'], 'ok')
+            resp = client.post('/check-entry', json={'entry': 'GAME'})
+            print(resp.json)
+            self.assertEqual(resp.json['result'], 'not-word')
 
     def test_invalid_word(self):
         """Testing a word that is not on the board"""


### PR DESCRIPTION
Changing `self.client.post` to `client.post` and updating the expected input did it for me:

```
$ python -m unittest test.FlaskTests
....resp:
{'result': 'not-word'}
.
----------------------------------------------------------------------
Ran 5 tests in 0.096s

OK
```